### PR TITLE
Update runtime to 49

### DIFF
--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -1,7 +1,7 @@
 {
     "app-id": "sm.puri.Chatty",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "chatty",
     "finish-args": [
@@ -86,27 +86,6 @@
                         "tag-pattern": "^v([\\d.]+)$"
                     },
                     "commit": "57ce34025066935f356fd539e6deb7a7a9952618"
-                }
-            ]
-        },
-        {
-            "name": "abseil",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DCMAKE_CXX_STANDARD=17",
-                "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
-                "-DABSL_PROPAGATE_CXX_STD=ON"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/abseil/abseil-cpp",
-                    "tag": "20250814.1",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "d38452e1ee03523a208362186fd42248ff2609f6"
                 }
             ]
         },
@@ -239,6 +218,9 @@
         {
             "name": "olm",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
Also, drop the abseil-cpp module, which is already provided by the runtime.

See: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/abseil-cpp.bst?ref_type=heads

Fixes: https://github.com/flathub/sm.puri.Chatty/issues/189