### PR TITLE
Update runtime to 50, Chatty to 0.8.9

### DIFF
--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -146,12 +146,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/google/libphonenumber",
-                    "tag": "v9.0.25",
+                    "tag": "v9.0.27",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
                     },
-                    "commit": "f048001255abd572a165543f9e11c430f589256f"
+                    "commit": "5f3d1d79faa242fb2948b714021f35b4603c86d8"
                 }
             ]
         },
@@ -186,12 +186,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git",
-                    "tag": "3.59.3",
+                    "tag": "3.60.0",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
                     },
-                    "commit": "5b9fccd338345f965730eaa96c9a7a8f9ca4d4ce"
+                    "commit": "9d0ce9fee8c88fb2f7c19b1df311f844bdab710f"
                 }
             ]
         },

--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -1,7 +1,7 @@
 {
     "app-id": "sm.puri.Chatty",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "chatty",
     "finish-args": [

--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -146,12 +146,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/google/libphonenumber",
-                    "tag": "v9.0.21",
+                    "tag": "v9.0.25",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
                     },
-                    "commit": "3b7cd902d9928110251c0d5c567ea76b6feabf16"
+                    "commit": "f048001255abd572a165543f9e11c430f589256f"
                 }
             ]
         },
@@ -186,12 +186,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git",
-                    "tag": "3.58.2",
+                    "tag": "3.59.3",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
                     },
-                    "commit": "9963c57f77a2ac305881d6b54b881c93118c3f84"
+                    "commit": "5b9fccd338345f965730eaa96c9a7a8f9ca4d4ce"
                 }
             ]
         },
@@ -206,12 +206,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/agx/feedbackd.git",
-                    "tag": "v0.8.8",
+                    "tag": "v0.8.9",
                     "x-checker-data": {
                         "type": "git",
                         "version-scheme": "semantic"
                     },
-                    "commit": "8ae3449d616e06240afb1e445727a08d6dee9559"
+                    "commit": "1be162a2e5aad10760f34b734e062c4fa250b159"
                 }
             ]
         },
@@ -270,12 +270,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-desktop",
-                    "tag": "44.4",
+                    "tag": "44.5",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
                     },
-                    "commit": "33516379260c09db7435432c7a250ce64afaad6e"
+                    "commit": "c214a5f3ff96d6add49bd88372c0c449bcab1967"
                 }
             ]
         },
@@ -303,12 +303,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/Chatty.git",
-                    "tag": "v0.8.8",
+                    "tag": "v0.8.9",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
                     },
-                    "commit": "1f9bf31f0b67edbb24d439311aec8a0213d3bee9"
+                    "commit": "8fcf8387917bf9d25a005c9e6b506026e77a4876"
                 }
             ]
         }

--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -21,13 +21,12 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/cmake",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
         "/share/aclocal",
+        "/share/bash-completion",
+        "/share/gir-1.0",
         "/share/vala",
         "*.la",
         "*.a"
@@ -63,9 +62,6 @@
         },
         {
             "name": "libical",
-            "cleanup": [
-                "/lib/cmake"
-            ],
             "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
@@ -120,7 +116,6 @@
                 "-Dprotobuf_BUILD_TESTS=OFF"
             ],
             "cleanup": [
-                "protoc",
                 "/bin",
                 "/doc",
                 "/lib/plugins"
@@ -142,7 +137,6 @@
             "name": "libphonenumber",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_CXX_STANDARD=17",
                 "-DREGENERATE_METADATA=OFF",
                 "-DUSE_BOOST=OFF",
                 "-DBUILD_TESTING=OFF",
@@ -166,7 +160,6 @@
             "name": "evolution-data-server",
             "cleanup": [
                 "/share/GConf",
-                "/lib/cmake",
                 "/lib/evolution-data-server/*-backends",
                 "/libexec",
                 "/share/dbus-1/services"

--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -115,6 +115,8 @@
             "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                "-Dprotobuf_LOCAL_DEPENDENCIES_ONLY=ON",
+                "-Dprotobuf_BUILD_SHARED_LIBS=ON",
                 "-Dprotobuf_BUILD_TESTS=OFF"
             ],
             "cleanup": [
@@ -127,8 +129,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/protocolbuffers/protobuf",
-                    "tag": "v21.12",
-                    "commit": "f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c"
+                    "tag": "v34.1",
+                    "commit": "4b0c3aacf0657fbf38253b38918d3358dd4319ec",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         },

--- a/sm.puri.Chatty.json
+++ b/sm.puri.Chatty.json
@@ -81,11 +81,11 @@
                     "type": "git",
                     "url": "https://github.com/libical/libical.git",
                     "tag": "v3.0.20",
+                    "commit": "57ce34025066935f356fd539e6deb7a7a9952618",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
-                    },
-                    "commit": "57ce34025066935f356fd539e6deb7a7a9952618"
+                    }
                 }
             ]
         },
@@ -97,11 +97,11 @@
                     "type": "git",
                     "url": "https://github.com/boostorg/boost",
                     "tag": "boost-1.90.0",
+                    "commit": "1bed2b0712b2119f20d66c5053def9173c8462a5",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^boost-([\\d.]+)$"
-                    },
-                    "commit": "1bed2b0712b2119f20d66c5053def9173c8462a5"
+                    }
                 }
             ],
             "build-commands": [
@@ -127,7 +127,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/protocolbuffers/protobuf",
-                    "tag": "v21.12"
+                    "tag": "v21.12",
+                    "commit": "f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c"
                 }
             ]
         },
@@ -147,11 +148,11 @@
                     "type": "git",
                     "url": "https://github.com/google/libphonenumber",
                     "tag": "v9.0.27",
+                    "commit": "5f3d1d79faa242fb2948b714021f35b4603c86d8",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
-                    },
-                    "commit": "5f3d1d79faa242fb2948b714021f35b4603c86d8"
+                    }
                 }
             ]
         },
@@ -187,11 +188,11 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/evolution-data-server.git",
                     "tag": "3.60.0",
+                    "commit": "9d0ce9fee8c88fb2f7c19b1df311f844bdab710f",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "9d0ce9fee8c88fb2f7c19b1df311f844bdab710f"
+                    }
                 }
             ]
         },
@@ -207,11 +208,11 @@
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/agx/feedbackd.git",
                     "tag": "v0.8.9",
+                    "commit": "1be162a2e5aad10760f34b734e062c4fa250b159",
                     "x-checker-data": {
                         "type": "git",
                         "version-scheme": "semantic"
-                    },
-                    "commit": "1be162a2e5aad10760f34b734e062c4fa250b159"
+                    }
                 }
             ]
         },
@@ -226,11 +227,11 @@
                     "type": "git",
                     "tag": "3.2.16",
                     "url": "https://gitlab.matrix.org/matrix-org/olm.git",
+                    "commit": "7e0c8277032e40308987257b711b38af8d77cc69",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "7e0c8277032e40308987257b711b38af8d77cc69"
+                    }
                 }
             ]
         },
@@ -255,11 +256,11 @@
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/mobile-broadband/ModemManager",
                     "tag": "1.24.2",
+                    "commit": "f2b9ab1ad78d322f32134a444b5b54c6e8160e19",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^(d+.d*[02468].d+)$"
-                    },
-                    "commit": "f2b9ab1ad78d322f32134a444b5b54c6e8160e19"
+                    }
                 }
             ]
         },
@@ -271,11 +272,11 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-desktop",
                     "tag": "44.5",
+                    "commit": "c214a5f3ff96d6add49bd88372c0c449bcab1967",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
-                    },
-                    "commit": "c214a5f3ff96d6add49bd88372c0c449bcab1967"
+                    }
                 }
             ]
         },
@@ -287,11 +288,11 @@
                     "type": "git",
                     "url": "https://source.puri.sm/Librem5/libcmatrix.git",
                     "tag": "v0.0.4",
+                    "commit": "5999b7afcb02b459fe13a2b93ab018f3af6d2b05",
                     "x-checker-data": {
                         "type": "git",
                         "version-scheme": "semantic"
-                    },
-                    "commit": "5999b7afcb02b459fe13a2b93ab018f3af6d2b05"
+                    }
                 }
             ]
         },
@@ -304,11 +305,11 @@
                     "type": "git",
                     "url": "https://gitlab.gnome.org/World/Chatty.git",
                     "tag": "v0.8.9",
+                    "commit": "8fcf8387917bf9d25a005c9e6b506026e77a4876",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
-                    },
-                    "commit": "8fcf8387917bf9d25a005c9e6b506026e77a4876"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
- Update the runtime version to 50
- Update Chatty to 0.8.9
- Update dependencies
- Fix build errors
- Fix linter warnings
- Improve cleanup commands to reduce the Flatpak size

**Please don't forget to test before merging.**